### PR TITLE
Reader writer state error

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -67,7 +67,7 @@ addCommandAlias (
 //////////////////////////////
 
 ThisBuild / organization := s"com.github.osxhacker.$systemName"
-ThisBuild / version := "0.7.1-SNAPSHOT"
+ThisBuild / version := "0.7.1"
 
 /// see: https://www.scala-sbt.org/1.x/docs/Publishing.html#Version+scheme
 ThisBuild / versionScheme := Some ("semver-spec")

--- a/build.sbt
+++ b/build.sbt
@@ -67,7 +67,7 @@ addCommandAlias (
 //////////////////////////////
 
 ThisBuild / organization := s"com.github.osxhacker.$systemName"
-ThisBuild / version := "0.7.0"
+ThisBuild / version := "0.7.1-SNAPSHOT"
 
 /// see: https://www.scala-sbt.org/1.x/docs/Publishing.html#Version+scheme
 ThisBuild / versionScheme := Some ("semver-spec")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.5
+sbt.version=1.12.7

--- a/services/chassis/src/main/scala/com/github/osxhacker/demo/chassis/domain/IndexedReaderWriterStateErrorT.scala
+++ b/services/chassis/src/main/scala/com/github/osxhacker/demo/chassis/domain/IndexedReaderWriterStateErrorT.scala
@@ -1,0 +1,1321 @@
+package com.github.osxhacker.demo.chassis.domain
+
+import scala.annotation.{
+	implicitNotFound,
+	unused
+	}
+
+import scala.language.postfixOps
+
+import cats._
+import cats.data.EitherT
+
+
+/**
+ * The '''IndexedReaderWriterStateErrorT''' type defines a stateful computation
+ * within the context ''F[_]'', from state ''SA'' to ''SB'', with an
+ * environment ''EnvT'', an accumulated log of type ''LogT'', and resulting in
+ * ''LogT'' and __either__ an error of type ''ErrorT'' or the result of the
+ * computation.  An important design decision enforced is __all__ operations are
+ * implemented such that results are woven through ''F[_]'' sequentially to
+ * ensure no copies of ''F[_]'' are produced.  Furthermore, additions to the
+ * managed ''LogT'' are disallowed once the __first__ error is detected in
+ * ''F[_]''.
+ *
+ * '''IndexedReaderWriterStateErrorT''' is conceptually similar to
+ * [[cats.data.IndexedReaderWriterStateT]], with the primary differences being
+ * ''LogT'' is always produced and the intrinsic ability to represent errors.
+ * As such, the behavior provided by this type is very similar as well
+ * (including the omission of nullary argument specifications).
+ */
+final class IndexedReaderWriterStateErrorT[F[_], EnvT, LogT, ErrorT, SA, SB, A] (
+	private[chassis] val runE : (EnvT, SA) =>
+		EitherT[F, (LogT, ErrorT), (LogT, SB, A)]
+	)
+	(implicit private val monadError : MonadError[F, ErrorT])
+	extends Serializable
+{
+	/// Class Imports
+	import cats.syntax.all._
+
+
+	/**
+	 * The adaptError method provides the ability to selectively transform
+	 * ''ErrorT'' instances when '''this''' instance represents an error state.
+	 */
+	def adaptError (pf : PartialFunction[ErrorT, ErrorT])
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SB, A] =
+		IndexedReaderWriterStateErrorT {
+			runE  (_, _) leftMap (_ map (pf applyOrElse (_, identity[ErrorT])))
+			}
+
+
+	/**
+	 * The ask method retrieves ''EnvT'' from this instance.
+	 */
+	def ask
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SB, EnvT] =
+		IndexedReaderWriterStateErrorT {
+			(env, sa) =>
+				runE (env, sa) map {
+					case (l, sb, _) =>
+						(l, sb, env)
+					}
+			}
+
+
+	/**
+	 * The bimap method modifies the existing state ''SB'' with '''fs''' and
+	 * the result of the computation ''A'' with '''fa'''.
+	 */
+	def bimap[SC, B] (fs : SB => SC, fa : A => B)
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SC, B] =
+		transform ((l, sb, a) => (l, fs (sb), fa (a)))
+
+
+	/**
+	 * The contramap method allows for the definition of an
+	 * '''IndexedReaderWriterStateErrorT''' having an initial state of ''S0'',
+	 * from which a ''SA'' can be derived.
+	 */
+	def contramap[S0] (f : S0 => SA)
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S0, SB, A] =
+		IndexedReaderWriterStateErrorT ((env, s0) => runE (env, f (s0)))
+
+
+	/**
+	 * The dimap method transforms the initial state of ''S0'' to ''SA''
+	 * __and then__ ''SB'' to ''S1'' as a single operation.
+	 */
+	def dimap[S0, S1] (f : S0 => SA)
+		(g : SB => S1)
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S0, S1, A] =
+		contramap (f) modify g
+
+
+	/**
+	 * The flatMap method uses the result of '''this''' instance to produce a
+	 * new '''IndexedReaderWriterStateErrorT''' if '''this''' does not represent
+	 * an error, having the combined logs and potentially a new state type
+	 * ''SC''.  Any existing or raised errors are represented in the return
+	 * value.
+	 */
+	def flatMap[SC, B] (
+		f : A => IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SB, SC, B]
+		)
+		(
+			implicit
+
+			@implicitNotFound (
+				"${LogT} must have a Semigroup defined and in the implicit scope"
+				)
+			semigroup : Semigroup[LogT]
+		)
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SC, B] =
+		IndexedReaderWriterStateErrorT {
+			(env, sa) =>
+				runE (env, sa) flatMap {
+					case (log, sb, a) =>
+						f (a).runE (env, sb)
+							.bimap (
+								l => (log |+| l._1) -> l._2,
+								r => (log |+| r._1, r._2, r._3)
+								)
+					}
+			}
+
+
+	/**
+	 * The flatMapF method is similar to `map`, with difference being '''f'''
+	 * results in a value ''B'' within the context ''F[_]''.  Errors within the
+	 * produced ''F[B]'' are represented in the return value.
+	 */
+	def flatMapF[B] (f : A => F[B])
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SB, B] =
+		transformF ((l, sb, a) => f (a) map (b => (l, sb, b)))
+
+
+	/**
+	 * The get method retrieves ''SB'' from this instance and makes it available
+	 * in the result.
+	 */
+	def get
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SB, SB] =
+		inspect (identity)
+
+
+	/**
+	 * The handleErrorWith method handles any ''ErrorT'' by producing an
+	 * '''IndexedReaderWriterStateErrorT''' based on the ''ErrorT'' contained in
+	 * '''this''' instance via the given '''f''' functor.  If '''this''' is not
+	 * in an error condition, '''f''' will not be evaluated.  Note that the
+	 * `handleError` method is __not__ defined in this type due to ''SA'' and
+	 * ''SB'' being potentially different types.
+	 */
+	def handleErrorWith (
+		f : ErrorT =>
+			IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SB, A]
+		)
+		(
+			implicit
+
+			@implicitNotFound (
+				"unable to resolve Semigroup[${LogT}] for handleErrorWith"
+				)
+			semigroup : Semigroup[LogT]
+		)
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SB, A] =
+		IndexedReaderWriterStateErrorT {
+			(env, sa) =>
+				runE (env, sa) handleErrorWith {
+					case (log, error) =>
+						f (error).runE (env, sa)
+							.bimap (
+								le => (log |+| le._1) -> le._2,
+								lsa => (log |+| lsa._1, lsa._2, lsa._3)
+								)
+					}
+				}
+
+
+	/**
+	 * The inspect method provides the resulting state ''SB'' to the given
+	 * functor '''f''' and made available in the result.
+	 */
+	def inspect[B] (f : SB => B)
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SB, B] =
+		transform ((l, sb, _) => (l, sb, f (sb)))
+
+
+	/**
+	 * The inspectAsk method provides both the environment ''EnvT'' and
+	 * resulting state ''SB'' to the given functor '''f''', whose value ''B'' is
+	 * made available in the result.
+	 */
+	def inspectAsk[B] (f : (EnvT, SB) => B)
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SB, B] =
+		IndexedReaderWriterStateErrorT {
+			(env, sa) =>
+				runE (env, sa) map {
+					case (l, sb, _) =>
+						(l, sb, f (env, sb))
+					}
+			}
+
+
+	/**
+	 * The inspectAskF method is similar to `inspectAsk`, with '''f''' being an
+	 * effectual function. Errors within the produced ''F[B]'' are represented
+	 * in the return value.
+	 */
+	def inspectAskF[B] (f : (EnvT, SB) => F[B])
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SB, B] =
+		IndexedReaderWriterStateErrorT {
+			(env, sa) =>
+				runE (env, sa) flatMapF {
+					case (l, sb, _) =>
+						f (env, sb).map (b => (l, sb, b).asRight[(LogT, ErrorT)])
+							.handleError {
+								error =>
+									(l -> error).asLeft[(LogT, SB, B)]
+									}
+					}
+			}
+
+
+	/**
+	 * The inspectF method is similar to `inspect`, with '''f''' being an
+	 * effectual function. Errors within the produced ''F[B]'' are represented
+	 * in the return value.
+	 */
+	def inspectF[B] (f : SB => F[B])
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SB, B] =
+		transformF ((l, sb, _) => f (sb) map (b => (l, sb, b)))
+
+
+	/**
+	 * The listen method combines ''A'' and ''LogT'' from '''this''' instance.
+	 */
+	def listen :
+		IndexedReaderWriterStateErrorT[
+			F,
+			EnvT,
+			LogT,
+			ErrorT,
+			SA,
+			SB,
+			(A, LogT)
+			] =
+		transform ((l, sb, a) => (l, sb, a -> l))
+
+
+	/**
+	 * The local method derives the initial ''EnvT'' from ''NewEnvT'' with the
+	 * given functor '''f'''.
+	 */
+	def local[NewEnvT] (f : NewEnvT => EnvT)
+		: IndexedReaderWriterStateErrorT[F, NewEnvT, LogT, ErrorT, SA, SB, A] =
+		IndexedReaderWriterStateErrorT ((env, sa) => runE (f (env), sa))
+
+
+	/**
+	 * The map method modifies the result ''A'' in '''this''' instance.
+	 */
+	def map[B] (f : A => B)
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SB, B] =
+		transform ((l, sb, a) => (l, sb, f (a)))
+
+
+	/**
+	 * The mapError method transforms ''ErrorT'' into ''NewErrorT'' if
+	 * '''this''' instance represents an error condition.
+	 */
+	def mapError[NewErrorT] (f : ErrorT => NewErrorT)
+		(
+			implicit
+
+			@implicitNotFound (
+				"unable to resolve MonadError[${F}, ${NewErrorT}] for mapError"
+				)
+			monadErrorE0 : MonadError[F, NewErrorT]
+		)
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, NewErrorT, SA, SB, A] =
+		IndexedReaderWriterStateErrorT {
+			runE (_, _).leftMap (_ map f) (monadErrorE0)
+			}
+
+
+	/**
+	 * The mapK method transforms '''this''' context from ''F[_]'' to ''G[_]''.
+	 */
+	def mapK[G[_]] (f : F ~> G)
+		(
+			implicit
+
+			@implicitNotFound (
+				"unable to resolve MonadError[${G}, ${ErrorT}] for mapK"
+				)
+			monadErrorG : MonadError[G, ErrorT]
+		)
+		: IndexedReaderWriterStateErrorT[G, EnvT, LogT, ErrorT, SA, SB, A] =
+		IndexedReaderWriterStateErrorT (runE (_, _) mapK f)
+
+
+	/**
+	 * The mapWritten transforms the ''LogT'' in '''this''' instance into
+	 * '''NewLogT''' using the given functor '''f'''.
+	 */
+	def mapWritten[NewLogT] (f : LogT => NewLogT)
+		: IndexedReaderWriterStateErrorT[F, EnvT, NewLogT, ErrorT, SA, SB, A] =
+		transform (f) (identity ((_, _, _)))
+
+
+	/**
+	 * The modify method applies the given functor '''f''' to the state ''SB''.
+	 */
+	def modify[SC] (f : SB => SC)
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SC, A] =
+		transform ((l, sb, a) => (l, f (sb), a))
+
+
+	/**
+	 * The modifyF method is similar to `modify`, with '''f''' being an
+	 * effectual function. Errors within the produced ''F[B]'' are represented
+	 * in the return value.
+	 */
+	def modifyF[SC] (f : SB => F[SC])
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SC, A] =
+		transformF ((l, sb, a) => f (sb) map (sc => (l, sc, a)))
+
+
+	/**
+	 * The recoverWith method handles a subset of ''ErrorT'' instances by
+	 * producing an '''IndexedReaderWriterStateErrorT''' based on the ''ErrorT''
+	 * contained in '''this''' instance via the given '''pf''' functor.  If
+	 * '''this''' is not in an error condition __or__ '''pf''' is not defined
+	 * for the contained error, '''pf''' will not be evaluated.  Note that the
+	 * `recover` method is __not__ defined in this type due to ''SA'' and ''SB''
+	 * being potentially different types.
+	 */
+	def recoverWith (
+		pf : PartialFunction[
+			ErrorT,
+			IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SB, A]
+			]
+		)
+		(
+			implicit
+
+			@implicitNotFound (
+				"unable to resolve Semigroup[${LogT}] for recoverWith"
+				)
+			semigroup : Semigroup[LogT]
+		)
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SB, A] =
+		IndexedReaderWriterStateErrorT {
+			(env, sa) =>
+				runE (env, sa) recoverWith {
+					case (log, error) if pf isDefinedAt error =>
+						pf (error).runE (env, sa)
+							.bimap (
+								le => (log |+| le._1) -> le._2,
+								lsb => (log |+| lsb._1, lsb._2, lsb._3)
+								)
+					}
+			}
+
+
+	/**
+	 * The reset method clears the ''LogT''.
+	 */
+	def reset (
+		implicit
+
+		@implicitNotFound ("unable to resolve Monoid[${LogT}] for reset")
+		monoid : Monoid[LogT]
+		)
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SB, A] =
+		transform ((_, sb, a) => (monoid empty, sb, a))
+
+
+	/**
+	 * The run method evaluates the operations '''this''' instance represents
+	 * using the given '''env''' and initial state '''sa''' instances.  Errors
+	 * raised during evaluation are returned within
+	 * ''F[(LogT, Either[ErrorT, (SB, A)])]''.  The ''LogT'' returned contains
+	 * entries up to the first error encountered, if any.
+	 */
+	def run (env : EnvT, sa : SA) : F[(LogT, Either[ErrorT, (SB, A)])] =
+		runE (env, sa).value map {
+			_ fold (
+				le => le._1 -> le._2.asLeft,
+				lsa => lsa._1 -> (lsa._2, lsa._3).asRight
+				)
+			}
+
+
+	/**
+	 * The runA method provides syntactic convenience for invoking the `run`
+	 * method and producing the ''A'' value of evaluating '''this''' when there
+	 * are no errors.
+	 */
+	def runA (env : EnvT, sa : SA) : F[(LogT, Either[ErrorT, A])] =
+		run (env, sa) map (_ map (_ map (_._2)))
+
+
+	/**
+	 * The runAndReport method `run`s '''this''' instance and then uses the
+	 * given '''reporter''' to unconditionally emit the resultant ''LogT''.  The
+	 * returned ''F[(SB, A)]'' therefore does not contain ''LogT''.  Any errors
+	 * are represented within the returned ''F[_]'' context (which differs from
+	 * what `run` returns).
+	 */
+	def runAndReport (env : EnvT, sa : SA)
+		(reporter : (LogT, Either[ErrorT, (SB, A)]) => F[Unit])
+		: F[(SB, A)] =
+		run (env, sa).flatTap (reporter.tupled)
+			.flatMap {
+				case (_, either) =>
+					either.liftTo[F]
+				}
+
+
+	/**
+	 * The runAndReportA method provides syntactic convenience for invoking the
+	 * `runAndReport` method and producing the ''A'' value of evaluating
+	 * '''this''' when there are no errors.
+	 */
+	def runAndReportA (env : EnvT, sa : SA)
+		(reporter : (LogT, Either[ErrorT, (SB, A)]) => F[Unit])
+		: F[A] =
+		runAndReport (env, sa) (reporter) map (_._2)
+
+
+	/**
+	 * The runAndReportS method provides syntactic convenience for invoking the
+	 * `runAndReport` method and producing the ''SB'' state value of evaluating
+	 * '''this''' when there are no errors.
+	 */
+	def runAndReportS (env : EnvT, sa : SA)
+		(reporter : (LogT, Either[ErrorT, (SB, A)]) => F[Unit])
+		: F[SB] =
+		runAndReport (env, sa) (reporter) map (_._1)
+
+
+	/**
+	 * The runS method provides syntactic convenience for invoking the `run`
+	 * method and producing the ''SB'' state value of evaluating '''this''' when
+	 * there are no errors.
+	 */
+	def runS (env : EnvT, sa : SA) : F[(LogT, Either[ErrorT, SB])] =
+		run (env, sa) map (_ map (_ map (_._1)))
+
+
+	/**
+	 * The set method replaces ''SB'' with the given '''state'''.
+	 */
+	def set[SC] (state : SC)
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SC, Unit] =
+		transform ((l, _, _) => (l, state, ()))
+
+
+	/**
+	 * The setF method is similar to `set`, with the given '''state''' being an
+	 * effectual value.
+	 */
+	def setF[SC] (state : F[SC])
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SC, Unit] =
+		transformF ((l, _, _) => state map (sc => (l, sc, ())))
+
+
+	/**
+	 * The tell method combines the given ''LogT'' '''entries''' with '''this'''
+	 * instance using the relevant [[cats.Semigroup]].
+	 */
+	def tell (entries : LogT)
+		(
+			implicit
+
+			@implicitNotFound (
+				"${LogT} must have a Semigroup defined and in the implicit scope"
+				)
+			semigroup : Semigroup[LogT]
+		)
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SB, A] =
+		transform ((l, sb, a) => (l |+| entries, sb, a))
+
+
+	/**
+	 * The tellF method is similar to `tell`, with '''f''' being an effectual
+	 * function. Errors within the produced ''F[B]'' are represented in the
+	 * return value.
+	 */
+	def tellF (entries : F[LogT])
+		(
+			implicit
+
+			@implicitNotFound (
+				"${LogT} must have a Semigroup defined and in the implicit scope"
+				)
+			semigroup : Semigroup[LogT]
+		)
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SB, A] =
+		transformF {
+			(l, sb, a) =>
+				entries map (ll => (l |+| ll, sb, a))
+			}
+
+
+	/**
+	 * This version of the transform method provides the ability to change the
+	 * type and/or content of ''LogT'', ''SB'', and ''A'' if '''this''' instance
+	 * does __not__ represent an error condition.
+	 */
+	def transform[NewLogT, SC, B] (flog : LogT => NewLogT)
+		(f : (NewLogT, SB, A) => (NewLogT, SC, B))
+		: IndexedReaderWriterStateErrorT[F, EnvT, NewLogT, ErrorT, SA, SC, B] =
+		IndexedReaderWriterStateErrorT {
+			runE (_, _) transform {
+				_ bimap (
+					e => flog (e._1) -> e._2,
+					lsba => f (flog (lsba._1), lsba._2, lsba._3)
+					)
+				}
+			}
+
+
+	/**
+	 * This version of the transform method provides the ability to change the
+	 * content of ''LogT'', type of ''SB'', and type of ''A'' if '''this'''
+	 * instance does __not__ represent an error condition.
+	 */
+	def transform[SC, B] (f : (LogT, SB, A) => (LogT, SC, B))
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SC, B] =
+		IndexedReaderWriterStateErrorT (runE (_, _) map f.tupled)
+
+
+	/**
+	 * The transformF method provides the ability to change the content of
+	 * ''LogT'', type of ''SB'', and type of ''A'' using the effectual function
+	 * '''f''' if '''this''' instance does __not__ represent an error condition.
+	 * Errors within the produced ''F[_]'' context are represented in the return
+	 * value.
+	 */
+	def transformF[SC, B] (f : (LogT, SB, A) => F[(LogT, SC, B)])
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SC, B] =
+		IndexedReaderWriterStateErrorT {
+			runE (_, _) flatMapF {
+				case (log, sb, a) =>
+					f (log, sb, a).map (_.asRight[(LogT, ErrorT)])
+						.handleError {
+							error =>
+								(log -> error).asLeft[(LogT, SC, B)]
+							}
+				}
+			}
+
+
+	/**
+	 * The written method retrieves the current ''LogT'' from '''this'''.
+	 */
+	def written
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SB, LogT] =
+		transform ((l, sb, _) => (l, sb, l))
+}
+
+
+object IndexedReaderWriterStateErrorT
+	extends IRWSETFunctions
+		with IRWSETPrioritizedImplicits
+{
+	/// Self Types Constraints
+	companion =>
+
+
+	/// Class Types
+	/**
+	 * The '''Combinators''' `trait` defines methods which have a reduced
+	 * generic parameter signature.
+	 *
+	 * @see [[com.github.osxhacker.demo.chassis.domain.IndexedReaderWriterStateErrorT.script]]
+	 */
+	sealed trait Combinators[F[_], EnvT, LogT, ErrorT]
+	{
+		/// Class Types
+		final type StateType[SA, SB, A] = IndexedReaderWriterStateErrorT[
+			F,
+			EnvT,
+			LogT,
+			ErrorT,
+			SA,
+			SB,
+			A
+			]
+
+
+		/// Instance Properties
+		implicit protected def ME : MonadError[F, ErrorT]
+		implicit protected def ML : Monoid[LogT]
+
+
+		/**
+		 * @see [[com.github.osxhacker.demo.chassis.domain.IndexedReaderWriterStateErrorT.ask]]
+		 */
+		@inline
+		final def ask[S] : StateType[S, S, EnvT] = companion ask
+
+
+		/**
+		 * @see [[com.github.osxhacker.demo.chassis.domain.IndexedReaderWriterStateErrorT.get]]
+		 */
+		@inline
+		final def get[S] : StateType[S, S, S] = companion get
+
+
+		/**
+		 * @see [[com.github.osxhacker.demo.chassis.domain.IndexedReaderWriterStateErrorT.inspect]]
+		 */
+		@inline
+		final def inspect[S, A] (f : S => A) : StateType[S, S, A] =
+			companion inspect f
+
+
+		/**
+		 * @see [[com.github.osxhacker.demo.chassis.domain.IndexedReaderWriterStateErrorT.inspectAsk]]
+		 */
+		@inline
+		final def inspectAsk[S, A] (f : (EnvT, S) => A) : StateType[S, S, A] =
+			companion inspectAsk f
+
+
+		/**
+		 * @see [[com.github.osxhacker.demo.chassis.domain.IndexedReaderWriterStateErrorT.inspectAskF]]
+		 */
+		@inline
+		final def inspectAskF[S, A] (f : (EnvT, S) => F[A])
+			: StateType[S, S, A] =
+			companion inspectAskF f
+
+
+		/**
+		 * @see [[com.github.osxhacker.demo.chassis.domain.IndexedReaderWriterStateErrorT.inspectF]]
+		 */
+		@inline
+		final def inspectF[S, A] (f : S => F[A]) : StateType[S, S, A] =
+			companion inspectF f
+
+
+		@inline
+		final def liftF[S, A] (fa : F[A]) : StateType[S, S, A] =
+			companion liftF fa
+
+
+		/**
+		 * @see [[com.github.osxhacker.demo.chassis.domain.IndexedReaderWriterStateErrorT.modify]]
+		 */
+		@inline
+		final def modify[SA, SB] (f : SA => SB) : StateType[SA, SB, Unit] =
+			companion modify f
+
+
+		/**
+		 * @see [[com.github.osxhacker.demo.chassis.domain.IndexedReaderWriterStateErrorT.modifyF]]
+		 */
+		@inline
+		final def modifyF[SA, SB] (f : SA => F[SB]) : StateType[SA, SB, Unit] =
+			companion modifyF f
+
+
+		@inline
+		final def pure[S, A] (a : A) : StateType[S, S, A] =
+			companion pure a
+
+
+		/**
+		 * @see [[com.github.osxhacker.demo.chassis.domain.IndexedReaderWriterStateErrorT.set]]
+		 */
+		@inline
+		final def set[S] (s : S) : StateType[S, S, Unit] = companion set s
+
+
+		/**
+		 * @see [[com.github.osxhacker.demo.chassis.domain.IndexedReaderWriterStateErrorT.setF]]
+		 */
+		@inline
+		final def setF[S] (sb : F[S]) : StateType[S, S, Unit] =
+			companion setF sb
+
+
+		/**
+		 * @see [[com.github.osxhacker.demo.chassis.domain.IndexedReaderWriterStateErrorT.tell]]
+		 */
+		@inline
+		final def tell[S] (entries : LogT) : StateType[S, S, Unit] =
+			companion tell entries
+
+
+		/**
+		 * @see [[com.github.osxhacker.demo.chassis.domain.IndexedReaderWriterStateErrorT.tellF]]
+		 */
+		@inline
+		final def tellF[S] (entries : F[LogT]) : StateType[S, S, Unit] =
+			companion tellF entries
+	}
+
+
+	final class PartiallyAppliedApplyF[ErrorT] (
+		@unused
+		private val dummy : Int = 0
+		)
+		extends AnyVal
+	{
+		/// Class Imports
+		import cats.syntax.applicativeError._
+
+
+		def apply[F[_], EnvT, LogT, SA, SB, A] (
+			f : (EnvT, SA) => F[(LogT, SB, A)]
+			)
+			(
+				implicit
+
+				@implicitNotFound (
+					"unable to resolve MonadError[${F}, ${ErrorT}] for apply"
+					)
+				monadError : MonadError[F, ErrorT],
+
+				@implicitNotFound (
+					"unable to resolve Monoid[${LogT}] for applyF"
+					)
+				monoid : Monoid[LogT]
+			)
+			: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SB, A] =
+			new IndexedReaderWriterStateErrorT (
+				(env, sa) =>
+					EitherT (f (env, sa).attempt).leftMap (monoid.empty -> _)
+				)
+	}
+
+
+	final class PartiallyAppliedScript[F[_], EnvT, LogT, ErrorT] ()
+	{
+		def apply[SA, SB, A] (
+			block : Combinators[F, EnvT, LogT, ErrorT] =>
+				IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SB, A]
+			)
+			(
+				implicit
+
+				@implicitNotFound (
+					"unable to resolve MonadError[${F}, ${ErrorT}] for apply"
+					)
+				monadError : MonadError[F, ErrorT],
+
+				@implicitNotFound (
+					"unable to resolve Monoid[${LogT}] for apply"
+					)
+				monoid : Monoid[LogT]
+			)
+			: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SB, A] =
+			block (
+				new Combinators[F, EnvT, LogT, ErrorT] {
+					override protected val ME = monadError
+					override protected val ML = monoid
+					}
+				)
+	}
+
+
+	/**
+	 * The apply method provides support for functional-style
+	 * '''IndexedReaderWriterStateErrorT''' creation.
+	 */
+	def apply[F[_], EnvT, LogT, ErrorT, SA, SB, A] (
+		runE : (EnvT, SA) => EitherT[F, (LogT, ErrorT), (LogT, SB, A)]
+		)
+		(
+			implicit
+
+			@implicitNotFound (
+				"unable to resolve MonadError[${F}, ${ErrorT}] for apply"
+				)
+			monadError : MonadError[F, ErrorT]
+		)
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SB, A] =
+		new IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SB, A] (
+			runE
+			)
+
+
+	/**
+	 * The applyF method employs the "partially applied" idiom to facilitate
+	 * creating an
+	 * [[com.github.osxhacker.demo.chassis.domain.IndexedReaderWriterStateErrorT]]
+	 * by only requiring collaborators to provide what type ''ErrorT'' is and
+	 * allowing the compiler to derive the rest.
+	 */
+	def applyF[ErrorT] : PartiallyAppliedApplyF[ErrorT] =
+		new PartiallyAppliedApplyF[ErrorT] ()
+
+
+	/**
+	 * The script method uses the "partially applied" idiom to support creating
+	 * [[com.github.osxhacker.demo.chassis.domain.IndexedReaderWriterStateErrorT]]
+	 * definitions using those available in
+	 * [[com.github.osxhacker.demo.chassis.domain.IndexedReaderWriterStateErrorT.Combinators]].
+	 * This technique allows definitions to avoid having to provide every
+	 * parameter type needed for
+	 * [[com.github.osxhacker.demo.chassis.domain.IndexedReaderWriterStateErrorT]]
+	 * in each method use.  For example:
+	 *
+	 * {{{
+	 *     script[IO, MyEnv, Vector[LogEntry], Throwable] {
+	 *         combinators =>
+	 *             import combinators._
+	 *
+	 *             for {
+	 *                 unsaved <- get[NewCompany]
+	 *                 _ <- tell (Vector (LogEntry ("saving new company ...")))
+	 *                 company <- inspectF[NewCompany, Company] (save)
+	 *                 } yield (unsaved, company)
+	 *         }
+	 * }}}
+	 */
+	def script[F[_], EnvT, LogT, ErrorT]
+		: PartiallyAppliedScript[F, EnvT, LogT, ErrorT] =
+		new PartiallyAppliedScript[F, EnvT, LogT, ErrorT] ()
+}
+
+
+sealed trait IRWSETFunctions
+{
+	/// Class Imports
+	import EitherT.rightT
+	import cats.syntax.applicativeError._
+	import cats.syntax.either._
+	import cats.syntax.functor._
+
+
+	final def ask[F[_], EnvT, LogT, ErrorT, S]
+		(
+			implicit
+
+			@implicitNotFound (
+				"unable to resolve MonadError[${F}, ${ErrorT}] for ask"
+				)
+			monadError : MonadError[F, ErrorT],
+
+			@implicitNotFound ("unable to resolve Monoid[${LogT}] for ask")
+			monoid : Monoid[LogT]
+		)
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, S, EnvT] =
+		createPureInstance ((env, s) => (monoid.empty, s, env))
+
+
+	final def get[F[_], EnvT, LogT, ErrorT, S]
+		(
+			implicit
+
+			@implicitNotFound (
+				"unable to resolve MonadError[${F}, ${ErrorT}] for get"
+				)
+			monadError : MonadError[F, ErrorT],
+
+			@implicitNotFound ("unable to resolve Monoid[${LogT}] for get")
+			monoid : Monoid[LogT]
+		)
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, S, S] =
+		createPureInstance ((_, s) => (monoid.empty, s, s))
+
+
+	final def inspect[F[_], EnvT, LogT, ErrorT, S, A] (f : S => A)
+		(
+			implicit
+
+			@implicitNotFound (
+				"unable to resolve MonadError[${F}, ${ErrorT}] for inspect"
+				)
+			monadError : MonadError[F, ErrorT],
+
+			@implicitNotFound ("unable to resolve Monoid[${LogT}] for inspect")
+			monoid : Monoid[LogT]
+		)
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, S, A] =
+		createPureInstance ((_, s) => (monoid.empty, s, f (s)))
+
+
+	final def inspectAsk[F[_], EnvT, LogT, ErrorT, S, A] (f : (EnvT, S) => A)
+		(
+			implicit
+
+			@implicitNotFound (
+				"unable to resolve MonadError[${F}, ${ErrorT}] for inspectAsk"
+				)
+			monadError : MonadError[F, ErrorT],
+
+			@implicitNotFound (
+				"unable to resolve Monoid[${LogT}] for inspectAsk"
+				)
+			monoid : Monoid[LogT]
+		)
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, S, A] =
+		createPureInstance ((env, s) => (monoid.empty, s, f (env, s)))
+
+
+	final def inspectAskF[F[_], EnvT, LogT, ErrorT, S, A] (
+		f : (EnvT, S) => F[A]
+		)
+		(
+			implicit
+
+			@implicitNotFound (
+				"unable to resolve MonadError[${F}, ${ErrorT}] for inspectAskF"
+				)
+			monadError : MonadError[F, ErrorT],
+
+			@implicitNotFound (
+				"unable to resolve Monoid[${LogT}] for inspectAskF"
+				)
+			monoid : Monoid[LogT]
+		)
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, S, A] =
+		createRecoverableInstance {
+			(env, s) =>
+				f (env, s) map ((monoid.empty, s, _))
+			}
+
+
+	final def inspectF[F[_], EnvT, LogT, ErrorT, S, A] (f : S => F[A])
+		(
+			implicit
+
+			@implicitNotFound (
+				"unable to resolve MonadError[${F}, ${ErrorT}] for inspectF"
+				)
+			monadError : MonadError[F, ErrorT],
+
+			@implicitNotFound ("unable to resolve Monoid[${LogT}] for inspectF")
+			monoid : Monoid[LogT]
+		)
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, S, A] =
+		createRecoverableInstance {
+			(_, sa) =>
+				f (sa) map ((monoid.empty, sa, _))
+			}
+
+
+	/**
+	 * The liftF method attempts to incorporate the given '''fa''' instance as
+	 * the result of a new
+	 * [[com.github.osxhacker.demo.chassis.domain.IndexedReaderWriterStateErrorT]]
+	 * instance.  Errors represented by '''fa''' are supported.
+	 */
+	final def liftF[F[_], EnvT, LogT, ErrorT, S, A] (fa : F[A])
+		(
+			implicit
+
+			@implicitNotFound (
+				"unable to resolve MonadError[${F}, ${ErrorT}] for liftF"
+				)
+			monadError : MonadError[F, ErrorT],
+
+			@implicitNotFound ("unable to resolve Monoid[${LogT}] for liftF")
+			monoid : Monoid[LogT]
+		)
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, S, A] =
+		createRecoverableInstance ((_, s) => fa map ((monoid.empty, s, _)))
+
+
+	final def modify[F[_], EnvT, LogT, ErrorT, SA, SB] (f : SA => SB)
+		(
+			implicit
+
+			@implicitNotFound (
+				"unable to resolve MonadError[${F}, ${ErrorT}] for modify"
+				)
+			monadError : MonadError[F, ErrorT],
+
+			@implicitNotFound ("unable to resolve Monoid[${LogT}] for modify")
+			monoid : Monoid[LogT]
+		)
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SB, Unit] =
+		createPureInstance ((_, sa) => (monoid.empty, f (sa), {}))
+
+
+	final def modifyF[F[_], EnvT, LogT, ErrorT, SA, SB] (f : SA => F[SB])
+		(
+			implicit
+
+			@implicitNotFound (
+				"unable to resolve MonadError[${F}, ${ErrorT}] for modifyF"
+				)
+			monadError : MonadError[F, ErrorT],
+
+			@implicitNotFound ("unable to resolve Monoid[${LogT}] for modifyF")
+			monoid : Monoid[LogT]
+		)
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SB, Unit] =
+		createRecoverableInstance {
+			(_, sa) =>
+				f (sa) map ((monoid.empty, _, {}))
+			}
+
+
+	final def pure[F[_], EnvT, LogT, ErrorT, S, A] (a : A)
+		(
+			implicit
+
+			@implicitNotFound (
+				"unable to resolve MonadError[${F}, ${ErrorT}] for pure"
+				)
+			monadError : MonadError[F, ErrorT],
+
+			@implicitNotFound ("unable to resolve Monoid[${LogT}] for pure")
+			monoid : Monoid[LogT]
+		)
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, S, A] =
+		createPureInstance ((_, s) => (monoid.empty, s, a))
+
+
+	final def set[F[_], EnvT, LogT, ErrorT, S] (s : S)
+		(
+			implicit
+
+			@implicitNotFound (
+				"unable to resolve MonadError[${F}, ${ErrorT}] for set"
+				)
+			monadError : MonadError[F, ErrorT],
+
+			@implicitNotFound ("unable to resolve Monoid[${LogT}] for set")
+			monoid : Monoid[LogT]
+		)
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, S, Unit] =
+		createPureInstance ((_, _) => (monoid.empty, s, {}))
+
+
+	final def setF[F[_], EnvT, LogT, ErrorT, S] (s : F[S])
+		(
+			implicit
+
+			@implicitNotFound (
+				"unable to resolve MonadError[${F}, ${ErrorT}] for setF"
+				)
+			monadError : MonadError[F, ErrorT],
+
+			@implicitNotFound ("unable to resolve Monoid[${LogT}] for setF")
+			monoid : Monoid[LogT]
+		)
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, S, Unit] =
+		createRecoverableInstance ((_, _) => s map ((monoid.empty, _, {})))
+
+
+	final def tell[F[_], EnvT, LogT, ErrorT, S] (entries : LogT)
+		(
+			implicit
+
+			@implicitNotFound (
+				"unable to resolve MonadError[${F}, ${ErrorT}] for tell"
+				)
+			monadError : MonadError[F, ErrorT]
+		)
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, S, Unit] =
+		createPureInstance ((_, s) => (entries, s, {}))
+
+
+	final def tellF[F[_], EnvT, LogT, ErrorT, S] (entries : F[LogT])
+		(
+			implicit
+
+			@implicitNotFound (
+				"unable to resolve MonadError[${F}, ${ErrorT}] for tellF"
+				)
+			monadError : MonadError[F, ErrorT],
+
+			@implicitNotFound ("unable to resolve Monoid[${LogT}] for tellF")
+			monoid : Monoid[LogT]
+		)
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, S, Unit] =
+		createRecoverableInstance ((_, s) => entries map ((_, s, {})))
+
+
+	@inline
+	private def createPureInstance[F[_], EnvT, LogT, ErrorT, SA, SB, A] (
+		f : (EnvT, SA) => (LogT, SB, A)
+		)
+		(implicit monadError : MonadError[F, ErrorT])
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SB, A] =
+		IndexedReaderWriterStateErrorT ((env, sa) => rightT (f (env, sa)))
+
+
+	@inline
+	private def createRecoverableInstance[F[_], EnvT, LogT, ErrorT, SA, SB, A] (
+		f : (EnvT, SA) => F[(LogT, SB, A)]
+		)
+		(
+			implicit
+
+			monadError : MonadError[F, ErrorT],
+			monoid : Monoid[LogT]
+		)
+		: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SB, A] =
+		IndexedReaderWriterStateErrorT {
+			(env, sa) =>
+				EitherT (
+					f (env, sa).map (_.asRight[(LogT, ErrorT)])
+						.handleError {
+							error =>
+								(monoid.empty -> error).asLeft[(LogT, SB, A)]
+							}
+					)
+			}
+}
+
+
+/**
+ * The '''IRWSETPrioritizedImplicits''' type defines prioritized `implicit`
+ * Cats type class instances available for
+ * [[com.github.osxhacker.demo.chassis.domain.IndexedReaderWriterStateErrorT]].
+ * Below are the priorities in descending order:
+ *
+ *   1. Type classes which are the most specialized in their hierarchy.
+ *
+ *   1. Type classes requiring ''SA'' and ''SB'' to be the same.
+ *
+ *   1. Type classes supporting differing ''SA'' and ''SB'' and are
+ *       generalizations of higher-priority ones.
+ */
+sealed trait IRWSETPrioritizedImplicits
+	extends IRWSETPrioritizedImplicits.MonoState
+{
+	/// Implicit Conversions
+	implicit final def irwsetBifunctor[F[_], EnvT, LogT, ErrorT, SA]
+		: Bifunctor[
+			IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, *, *]
+			] =
+		new Bifunctor[
+			IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, *, *]
+			] {
+			override def bimap[A, B, C, D] (
+				fab : IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, A, B]
+				)
+				(f : A => C, g : B => D)
+				: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, C, D] =
+				fab.bimap (f, g)
+			}
+
+
+	implicit final def irwsetContravariant[F[_], EnvT, LogT, ErrorT, SB, R]
+		: Contravariant[
+			IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, *, SB, R]
+			] =
+		new Contravariant[
+			IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, *, SB, R]
+			] {
+			override def contramap[A, B] (
+				fa : IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, A, SB, R]
+				)
+				(f : B => A)
+				: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, B, SB, R] =
+				fa contramap f
+			}
+}
+
+
+private[chassis] object IRWSETPrioritizedImplicits
+{
+	/// Class Types
+	private sealed trait AbstractFunctor[F[_], EnvT, LogT, ErrorT, SA, SB]
+		extends Functor[
+			IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SB, *]
+			]
+	{
+		final override def map[A, B] (
+			fa : IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SB, A]
+			)
+			(f : A => B)
+			: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SB, B] =
+			fa map f
+	}
+
+
+	private final class DefaultMonadError[F[_], EnvT, LogT, ErrorT, S] ()
+		(
+			implicit
+
+			private val monadError : MonadError[F, ErrorT],
+			private val monoid : Monoid[LogT]
+		)
+		extends MonadError[
+			ReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, *],
+			ErrorT
+			]
+			with AbstractFunctor[F, EnvT, LogT, ErrorT, S, S]
+	{
+		/// Class Imports
+		import cats.syntax.either._
+		import cats.syntax.semigroup._
+
+
+		/// Instance Properties
+		private val indexed = IndexedReaderWriterStateErrorT
+
+
+		override def flatMap[A, B] (
+			fa : ReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, A]
+			)
+			(f : A => ReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, B])
+			: ReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, B] =
+			fa flatMap f
+
+
+		override def handleErrorWith[A] (
+			fa : ReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, A]
+			)
+			(f : ErrorT => ReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, A])
+			: ReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, A] =
+			fa handleErrorWith f
+
+
+		override def pure[A] (a : A)
+			: ReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, A] =
+			indexed pure a
+
+
+		override def raiseError[A] (error : ErrorT)
+			: ReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, A] =
+			indexed liftF (monadError raiseError error)
+
+
+		override def recoverWith[A] (
+			fa : ReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, A]
+			)
+			(
+				pf :
+					PartialFunction[
+						ErrorT,
+						ReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, A]
+						]
+			)
+			: ReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, A] =
+			fa recoverWith pf
+
+
+		override def tailRecM[A, B] (a : A)
+			(
+				f : A =>
+					ReaderWriterStateErrorT[
+						F,
+						EnvT,
+						LogT,
+						ErrorT,
+						S,
+						Either[A, B]
+						]
+			)
+			: ReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, B] =
+			IndexedReaderWriterStateErrorT {
+				(env, s0) =>
+					val result = monadError.tailRecM ((monoid.empty, s0, a)) {
+						current =>
+							val next = f (current._3).runE (env, current._2)
+								.value
+
+							monadError.map (next) {
+								/// Continue with the recursion.
+								case Right ((l, s, Left (a))) =>
+									(current._1 |+| l, s, a).asLeft
+
+								/// Stop recursion due to an error.
+								case Left ((l, e)) =>
+									Left ((current._1 |+| l, e)).asRight
+
+								/// Stop recursion due to a terminating
+								/// successful condition.
+								case Right ((l, s, Right (a))) =>
+									Right ((current._1 |+| l, s, a)).asRight
+								}
+						}
+
+					EitherT (result)
+				}
+	}
+
+
+	sealed trait IndexedState
+	{
+		/// Implicit Conversions
+		implicit final def irwsetFunctor[F[_], EnvT, LogT, ErrorT, SA, SB]
+			: Functor[
+			IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SB, *]
+			] =
+			new Functor[
+				IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SB, *]
+				] {
+				override def map[A, B] (
+					fa : IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SB, A]
+					)
+					(f : A => B)
+					: IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, SA, SB, B] =
+					fa map f
+			}
+	}
+
+
+	sealed trait MonoState
+		extends IndexedState
+	{
+		/// Implicit Conversions
+		implicit final def rwsetMonadError[F[_], EnvT, LogT, ErrorT, S] (
+			implicit
+
+			monadError : MonadError[F, ErrorT],
+			monoid : Monoid[LogT]
+			)
+			: MonadError[
+				ReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, *],
+				ErrorT
+				] =
+			new DefaultMonadError ()
+	}
+}
+

--- a/services/chassis/src/main/scala/com/github/osxhacker/demo/chassis/domain/ReaderWriterStateErrorT.scala
+++ b/services/chassis/src/main/scala/com/github/osxhacker/demo/chassis/domain/ReaderWriterStateErrorT.scala
@@ -1,0 +1,442 @@
+package com.github.osxhacker.demo.chassis.domain
+
+import scala.annotation.implicitNotFound
+import scala.language.postfixOps
+
+import cats.{
+	Endo,
+	MonadError,
+	Monoid
+	}
+
+
+/**
+ * The '''ReaderWriterStateErrorT''' `object` defines a pseudo-companion for the
+ * `type` defined in the `package` with the same name.
+ *
+ * @see [[com.github.osxhacker.demo.chassis.domain.IndexedReaderWriterStateErrorT]]
+ */
+object ReaderWriterStateErrorT
+	extends RWSETFunctions
+{
+	/// Self Types Constraints
+	functions =>
+
+
+	/// Class Types
+	/**
+	 * The '''Combinators''' `trait` defines methods which have a reduced
+	 * generic parameter signature.
+	 *
+	 * @see [[com.github.osxhacker.demo.chassis.domain.ReaderWriterStateErrorT.script]]
+	 */
+	sealed trait Combinators[F[_], EnvT, LogT, ErrorT, S]
+	{
+		/// Class Types
+		final type StateType[A] = ReaderWriterStateErrorT[
+			F,
+			EnvT,
+			LogT,
+			ErrorT,
+			S,
+			A
+			]
+
+
+		/// Instance Properties
+		implicit protected def ME : MonadError[F, ErrorT]
+		implicit protected def ML : Monoid[LogT]
+
+
+		/**
+		 * @see [[com.github.osxhacker.demo.chassis.domain.IndexedReaderWriterStateErrorT.ask]]
+		 */
+		@inline
+		final def ask : StateType[EnvT] = functions ask
+
+
+		/**
+		 * @see [[com.github.osxhacker.demo.chassis.domain.IndexedReaderWriterStateErrorT.get]]
+		 */
+		@inline
+		final def get : StateType[S] = functions get
+
+
+		/**
+		 * @see [[com.github.osxhacker.demo.chassis.domain.IndexedReaderWriterStateErrorT.inspect]]
+		 */
+		@inline
+		final def inspect[A] (f : S => A) : StateType[A] = functions inspect f
+
+
+		/**
+		 * @see [[com.github.osxhacker.demo.chassis.domain.IndexedReaderWriterStateErrorT.inspectAsk]]
+		 */
+		@inline
+		final def inspectAsk[A] (f : (EnvT, S) => A) : StateType[A] =
+			functions inspectAsk f
+
+
+		/**
+		 * @see [[com.github.osxhacker.demo.chassis.domain.IndexedReaderWriterStateErrorT.inspectAskF]]
+		 */
+		@inline
+		final def inspectAskF[A] (f : (EnvT, S) => F[A]) : StateType[A] =
+			functions inspectAskF f
+
+
+		/**
+		 * @see [[com.github.osxhacker.demo.chassis.domain.IndexedReaderWriterStateErrorT.inspectF]]
+		 */
+		@inline
+		final def inspectF[A] (f : S => F[A]) : StateType[A] =
+			functions inspectF f
+
+
+		@inline
+		final def liftF[A] (fa : F[A]) : StateType[A] = functions liftF fa
+
+
+		/**
+		 * @see [[com.github.osxhacker.demo.chassis.domain.IndexedReaderWriterStateErrorT.modify]]
+		 */
+		@inline
+		final def modify (f : Endo[S]) : StateType[Unit] = functions modify f
+
+
+		/**
+		 * @see [[com.github.osxhacker.demo.chassis.domain.IndexedReaderWriterStateErrorT.modifyF]]
+		 */
+		@inline
+		final def modifyF (f : S => F[S]) : StateType[Unit] =
+			functions modifyF f
+
+
+		@inline
+		final def pure[A] (a : A) : StateType[A] = functions pure a
+
+
+		/**
+		 * @see [[com.github.osxhacker.demo.chassis.domain.IndexedReaderWriterStateErrorT.set]]
+		 */
+		@inline
+		final def set (s : S) : StateType[Unit] = functions set s
+
+
+		/**
+		 * @see [[com.github.osxhacker.demo.chassis.domain.IndexedReaderWriterStateErrorT.setF]]
+		 */
+		@inline
+		final def setF (sb : F[S]) : StateType[Unit] = functions setF sb
+
+
+		/**
+		 * @see [[com.github.osxhacker.demo.chassis.domain.IndexedReaderWriterStateErrorT.tell]]
+		 */
+		@inline
+		final def tell (entries : LogT) : StateType[Unit] =
+			functions tell entries
+
+
+		/**
+		 * @see [[com.github.osxhacker.demo.chassis.domain.IndexedReaderWriterStateErrorT.tellF]]
+		 */
+		@inline
+		final def tellF (entries : F[LogT]) : StateType[Unit] =
+			functions tellF entries
+	}
+
+
+	final class PartiallyAppliedScript[F[_], EnvT, LogT, ErrorT, S] ()
+	{
+		def apply[A] (
+			block : Combinators[F, EnvT, LogT, ErrorT, S] =>
+				ReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, A]
+			)
+			(
+				implicit
+
+				@implicitNotFound (
+					"unable to resolve MonadError[${F}, ${ErrorT}] for apply"
+					)
+				monadError : MonadError[F, ErrorT],
+
+				@implicitNotFound (
+					"unable to resolve Monoid[${LogT}] for apply"
+					)
+				monoid : Monoid[LogT]
+			)
+			: ReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, A] =
+			block (
+				new Combinators[F, EnvT, LogT, ErrorT, S] {
+					override protected val ME = monadError
+					override protected val ML = monoid
+					}
+				)
+	}
+
+
+	/**
+	 * The script method uses the "partially applied" idiom to support creating
+	 * [[com.github.osxhacker.demo.chassis.domain.ReaderWriterStateErrorT]]
+	 * definitions using those available in
+	 * [[com.github.osxhacker.demo.chassis.domain.ReaderWriterStateErrorT.Combinators]].
+	 * This technique allows definitions to avoid having to provide every
+	 * parameter type needed for
+	 * [[com.github.osxhacker.demo.chassis.domain.ReaderWriterStateErrorT]]
+	 * in each method use.  For example:
+	 *
+	 * {{{
+	 *     script[IO, MyEnv, Vector[LogEntry], Throwable, NewCompany] {
+	 *         combinators =>
+	 *             import combinators._
+	 *
+	 *             for {
+	 *                 unsaved <- get
+	 *                 _ <- tell (Vector (LogEntry ("saving new company ...")))
+	 *                 company <- inspectF[Company] (save)
+	 *                 } yield (unsaved, company)
+	 *         }
+	 * }}}
+	 */
+	def script[F[_], EnvT, LogT, ErrorT, S]
+		: PartiallyAppliedScript[F, EnvT, LogT, ErrorT, S] =
+		new PartiallyAppliedScript[F, EnvT, LogT, ErrorT, S] ()
+}
+
+
+sealed trait RWSETFunctions
+{
+	final def ask[F[_], EnvT, LogT, ErrorT, S]
+		(
+			implicit
+
+			@implicitNotFound (
+				"unable to resolve MonadError[${F}, ${ErrorT}] for ask"
+				)
+			monadError : MonadError[F, ErrorT],
+
+			@implicitNotFound ("unable to resolve Monoid[${LogT}] for ask")
+			monoid : Monoid[LogT]
+		)
+		: ReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, EnvT] =
+		IndexedReaderWriterStateErrorT ask
+
+
+	final def get[F[_], EnvT, LogT, ErrorT, S]
+		(
+			implicit
+
+			@implicitNotFound (
+				"unable to resolve MonadError[${F}, ${ErrorT}] for get"
+				)
+			monadError : MonadError[F, ErrorT],
+
+			@implicitNotFound ("unable to resolve Monoid[${LogT}] for get")
+			monoid : Monoid[LogT]
+		)
+		: ReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, S] =
+		IndexedReaderWriterStateErrorT get
+
+
+	final def inspect[F[_], EnvT, LogT, ErrorT, S, A] (f : S => A)
+		(
+			implicit
+
+			@implicitNotFound (
+				"unable to resolve MonadError[${F}, ${ErrorT}] for inspect"
+				)
+			monadError : MonadError[F, ErrorT],
+
+			@implicitNotFound ("unable to resolve Monoid[${LogT}] for inspect")
+			monoid : Monoid[LogT]
+		)
+		: ReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, A] =
+		IndexedReaderWriterStateErrorT inspect f
+
+
+	final def inspectAsk[F[_], EnvT, LogT, ErrorT, S, A] (f : (EnvT, S) => A)
+		(
+			implicit
+
+			@implicitNotFound (
+				"unable to resolve MonadError[${F}, ${ErrorT}] for inspectAsk"
+				)
+			monadError : MonadError[F, ErrorT],
+
+			@implicitNotFound (
+				"unable to resolve Monoid[${LogT}] for inspectAsk"
+				)
+			monoid : Monoid[LogT]
+		)
+		: ReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, A] =
+		IndexedReaderWriterStateErrorT inspectAsk f
+
+
+	final def inspectAskF[F[_], EnvT, LogT, ErrorT, S, A] (
+		f : (EnvT, S) => F[A]
+		)
+		(
+			implicit
+
+			@implicitNotFound (
+				"unable to resolve MonadError[${F}, ${ErrorT}] for inspectAskF"
+				)
+			monadError : MonadError[F, ErrorT],
+
+			@implicitNotFound (
+				"unable to resolve Monoid[${LogT}] for inspectAskF"
+				)
+			monoid : Monoid[LogT]
+		)
+		: ReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, A] =
+		IndexedReaderWriterStateErrorT inspectAskF f
+
+
+	final def inspectF[F[_], EnvT, LogT, ErrorT, S, A] (f : S => F[A])
+		(
+			implicit
+
+			@implicitNotFound (
+				"unable to resolve MonadError[${F}, ${ErrorT}] for inspectF"
+				)
+			monadError : MonadError[F, ErrorT],
+
+			@implicitNotFound ("unable to resolve Monoid[${LogT}] for inspectF")
+			monoid : Monoid[LogT]
+		)
+		: ReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, A] =
+		IndexedReaderWriterStateErrorT inspectF f
+
+
+	/**
+	 * The liftF method attempts to incorporate the given '''fa''' instance as
+	 * the result of a new
+	 * [[com.github.osxhacker.demo.chassis.domain.ReaderWriterStateErrorT]]
+	 * instance.  Errors represented by '''fa''' are supported.
+	 */
+	final def liftF[F[_], EnvT, LogT, ErrorT, S, A] (fa : F[A])
+		(
+			implicit
+
+			@implicitNotFound (
+				"unable to resolve MonadError[${F}, ${ErrorT}] for liftF"
+				)
+			monadError : MonadError[F, ErrorT],
+
+			@implicitNotFound ("unable to resolve Monoid[${LogT}] for liftF")
+			monoid : Monoid[LogT]
+		)
+		: ReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, A] =
+		IndexedReaderWriterStateErrorT liftF fa
+
+
+	final def modify[F[_], EnvT, LogT, ErrorT, S] (f : Endo[S])
+		(
+			implicit
+
+			@implicitNotFound (
+				"unable to resolve MonadError[${F}, ${ErrorT}] for modify"
+				)
+			monadError : MonadError[F, ErrorT],
+
+			@implicitNotFound ("unable to resolve Monoid[${LogT}] for modify")
+			monoid : Monoid[LogT]
+		)
+		: ReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, Unit] =
+		IndexedReaderWriterStateErrorT modify f
+
+
+	final def modifyF[F[_], EnvT, LogT, ErrorT, S] (f : S => F[S])
+		(
+			implicit
+
+			@implicitNotFound (
+				"unable to resolve MonadError[${F}, ${ErrorT}] for modifyF"
+				)
+			monadError : MonadError[F, ErrorT],
+
+			@implicitNotFound ("unable to resolve Monoid[${LogT}] for modifyF")
+			monoid : Monoid[LogT]
+		)
+		: ReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, Unit] =
+		IndexedReaderWriterStateErrorT modifyF f
+
+
+	final def pure[F[_], EnvT, LogT, ErrorT, S, A] (a : A)
+		(
+			implicit
+
+			@implicitNotFound (
+				"unable to resolve MonadError[${F}, ${ErrorT}] for pure"
+				)
+			monadError : MonadError[F, ErrorT],
+
+			@implicitNotFound ("unable to resolve Monoid[${LogT}] for pure")
+			monoid : Monoid[LogT]
+		)
+		: ReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, A] =
+		IndexedReaderWriterStateErrorT pure a
+
+
+	final def set[F[_], EnvT, LogT, ErrorT, S] (s : S)
+		(
+			implicit
+
+			@implicitNotFound (
+				"unable to resolve MonadError[${F}, ${ErrorT}] for set"
+				)
+			monadError : MonadError[F, ErrorT],
+
+			@implicitNotFound ("unable to resolve Monoid[${LogT}] for set")
+			monoid : Monoid[LogT]
+		)
+		: ReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, Unit] =
+		IndexedReaderWriterStateErrorT set s
+
+
+	final def setF[F[_], EnvT, LogT, ErrorT, S] (s : F[S])
+		(
+			implicit
+
+			@implicitNotFound (
+				"unable to resolve MonadError[${F}, ${ErrorT}] for setF"
+				)
+			monadError : MonadError[F, ErrorT],
+
+			@implicitNotFound ("unable to resolve Monoid[${LogT}] for setF")
+			monoid : Monoid[LogT]
+		)
+		: ReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, Unit] =
+		IndexedReaderWriterStateErrorT setF s
+
+
+	final def tell[F[_], EnvT, LogT, ErrorT, S] (entries : LogT)
+		(
+			implicit
+
+			@implicitNotFound (
+				"unable to resolve MonadError[${F}, ${ErrorT}] for tell"
+				)
+			monadError : MonadError[F, ErrorT]
+		)
+		: ReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, Unit] =
+		IndexedReaderWriterStateErrorT tell entries
+
+
+	final def tellF[F[_], EnvT, LogT, ErrorT, S] (entries : F[LogT])
+		(
+			implicit
+
+			@implicitNotFound (
+				"unable to resolve MonadError[${F}, ${ErrorT}] for tellF"
+				)
+			monadError : MonadError[F, ErrorT],
+
+			@implicitNotFound ("unable to resolve Monoid[${LogT}] for tellF")
+			monoid : Monoid[LogT]
+		)
+		: ReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, Unit] =
+		IndexedReaderWriterStateErrorT tellF entries
+}
+

--- a/services/chassis/src/main/scala/com/github/osxhacker/demo/chassis/domain/algorithm/FindField.scala
+++ b/services/chassis/src/main/scala/com/github/osxhacker/demo/chassis/domain/algorithm/FindField.scala
@@ -28,7 +28,7 @@ import shapeless.labelled.FieldType
  * requisite instance.
  *
  * Conceptually, '''FindField''' abstracts a named field's location.  Another
- * way to think about it is as being a higher-kinded [[monacle.Getter]].
+ * way to think about it is as being a higher-kinded [[monocle.Getter]].
  */
 trait FindField[A, K <: Symbol, V]
 {

--- a/services/chassis/src/main/scala/com/github/osxhacker/demo/chassis/domain/algorithm/InferDomainEvents.scala
+++ b/services/chassis/src/main/scala/com/github/osxhacker/demo/chassis/domain/algorithm/InferDomainEvents.scala
@@ -20,7 +20,7 @@ import shapeless.ops.{
 /**
  * The '''InferDomainEvents''' type defines the algorithm for determining, or
  * "inferring", what ''AllowableEventsT'' should be produced.  What ones created
- * are the responsibility of the ''InferPoly'' [[shapeless.Poly2]].  Its
+ * are the responsibility of the ''InferPolyT'' [[shapeless.Poly2]].  Its
  * `implicit` signatures must be of the form:
  *
  * {{{
@@ -36,8 +36,8 @@ import shapeless.ops.{
  * Each defined [[shapeless.Cases.Case2]] is evaluated with `from` and `to` (in
  * that order).  Note that requisite collaborators __must__ be resolvable in the
  * `implicit` scope.  When they are needed, the [[shapeless.Cases.Case2]]
- * __must__ be an `implicit def`.  A common collaborator is an `implicit` scoped
- * environment and can be found in most ''InferPolyT'' definitions.
+ * __must__ be an `implicit def`.  A common collaborator is an `implicit`ly
+ * scoped environment and can be found in many ''InferPolyT'' definitions.
  */
 final class InferDomainEvents[
 	EntityT,
@@ -64,6 +64,7 @@ final class InferDomainEvents[
 	{
 		implicit def summoner[PolyT <: Poly2, EventT] (
 			implicit
+
 			@implicitNotFound (
 				"could not resolve a handler in ${PolyT} having the " +
 				"signature of " +
@@ -109,6 +110,7 @@ final class InferDomainEvents[
 		] ()
 		(
 			implicit
+
 			@unused
 			toHList : coproduct.ToHList.Aux[
 				AllowableEventsT,

--- a/services/chassis/src/main/scala/com/github/osxhacker/demo/chassis/domain/package.scala
+++ b/services/chassis/src/main/scala/com/github/osxhacker/demo/chassis/domain/package.scala
@@ -24,5 +24,14 @@ package object domain
 	 * which represent an error or an instance of ''A''.
 	 */
 	type ErrorOr[+A] = Either[Throwable, A]
+
+
+	/**
+	 * The ReaderWriterStateErrorT type defines the contract for using
+	 * [[com.github.osxhacker.demo.chassis.domain.IndexedReaderWriterStateErrorT]]
+	 * with the same initial and ending state types.
+	 */
+	type ReaderWriterStateErrorT[F[_], EnvT, LogT, ErrorT, S, A] =
+		IndexedReaderWriterStateErrorT[F, EnvT, LogT, ErrorT, S, S, A]
 }
 

--- a/services/chassis/src/main/scala/com/github/osxhacker/demo/chassis/monitoring/logging/AbstractChangeReport.scala
+++ b/services/chassis/src/main/scala/com/github/osxhacker/demo/chassis/monitoring/logging/AbstractChangeReport.scala
@@ -14,13 +14,13 @@ import org.typelevel.log4cats.SelfAwareStructuredLogger
 
 
 /**
- * The '''AbstractChangeReport''' `object` defines the algorithm for
- * producing a report of significant changes relevant to the ''DomainT''
- * entity.  Key to this is what exists in the persistent store ''before'' and
- * ''after'' a persistence operation.  [[cats.data.Ior]] is the ideal
- * representation of this.  ''HavingCreated'', ''HavingDeleted'', and
- * ''HavingModified'' are defined to enhance semantic value beyond the contract
- * established by [[cats.data.Ior]].
+ * The '''AbstractChangeReport''' type defines the algorithm for producing a
+ * report of significant changes relevant to the ''DomainT'' entity.  Key to
+ * this is what exists in the persistent store ''before'' and ''after'' a
+ * persistence operation.  [[cats.data.Ior]] is the ideal representation of
+ * this.  ''HavingCreated'', ''HavingDeleted'', and ''HavingModified'' are
+ * defined to enhance semantic value beyond the contract established by
+ * [[cats.data.Ior]].
  *
  * When there was no ''DomainT'' ''before'' and now there is one ''after'', the
  * ''DomainT'' has been created.  This equates to a [[cats.data.Ior.Right]].
@@ -33,7 +33,7 @@ import org.typelevel.log4cats.SelfAwareStructuredLogger
  * existing ''DomainT'' has been performed.  This equates to a
  * [[cats.data.Ior.Both]].
  */
-abstract class AbstractChangeReport[DomainT, EnvT[F[_]]] ()
+abstract class AbstractChangeReport[DomainT, EnvT[_[_]]] ()
 {
 	/// Class Imports
 	import cats.syntax.all._
@@ -97,6 +97,7 @@ abstract class AbstractChangeReport[DomainT, EnvT[F[_]]] ()
 	final def apply[F[_]] (change : Option[Ior[DomainT, DomainT]])
 		(
 			implicit
+
 			env : EnvT[F],
 			monad : Monad[F]
 		)
@@ -116,12 +117,13 @@ abstract class AbstractChangeReport[DomainT, EnvT[F[_]]] ()
 	final def apply[F[_]] (change : Ior[DomainT, DomainT])
 		(
 			implicit
+
 			env : EnvT[F],
 			monad : Monad[F]
 		)
 		: F[Unit] =
 		change.fold[ReportType[F]] (deleted, created, modified)
-			.written (monad)
+			.written
 			.product (createLogger[F] (env))
 			.flatMap {
 				case (report, log) =>

--- a/services/chassis/src/main/scala/com/github/osxhacker/demo/chassis/monitoring/logging/LogEntry.scala
+++ b/services/chassis/src/main/scala/com/github/osxhacker/demo/chassis/monitoring/logging/LogEntry.scala
@@ -16,20 +16,21 @@ import com.github.osxhacker.demo.chassis.monitoring.{
  * intended to be emitted effectually.
  */
 sealed abstract class LogEntry (
+	override val message : String,
+	override val cause : Option[Throwable],
 	private val subsystem : Subsystem,
-	private val message : String,
-	private val cause : Option[Throwable],
-	private val context : Map[String, String]
+	private val entries : Map[String, String]
 	)
 	extends Product
 		with Serializable
+		with Loggable
 {
 	/// Class Imports
 	import mouse.option._
 
 
 	/// Instance Properties
-	private lazy val entries = subsystem.addTo (context)
+	override lazy val context = subsystem addTo entries
 
 
 	/**
@@ -47,7 +48,7 @@ sealed abstract class LogEntry (
 		(implicit logger : Logger)
 		: Unit =
 		if (logger.isDebugEnabled)
-			Using (ScopedMDC (entries)) {
+			Using (ScopedMDC (context)) {
 				 emit (_.debug (message), problem => _.debug (message, problem))
 				 }
 
@@ -59,7 +60,7 @@ sealed abstract class LogEntry (
 	final def error ()
 		(implicit logger : Logger)
 		: Unit =
-		Using (ScopedMDC (entries)) {
+		Using (ScopedMDC (context)) {
 			emit (_.error (message), problem => _.error (message, problem))
 			}
 
@@ -71,7 +72,7 @@ sealed abstract class LogEntry (
 	final def info ()
 		(implicit logger : Logger)
 		: Unit =
-		Using (ScopedMDC (entries)) {
+		Using (ScopedMDC (context)) {
 			emit (_.info (message), problem => _.info (message, problem))
 			}
 
@@ -83,18 +84,18 @@ sealed abstract class LogEntry (
 	final def warn ()
 		(implicit logger : Logger)
 		: Unit =
-		Using (ScopedMDC (entries)) {
+		Using (ScopedMDC (context)) {
 			emit (_.warn (message), problem => _.warn (message, problem))
 			}
 
 
 	@inline
 	private def emit (
-		withoutError : ScopedMDC => Unit,
-		withError : Throwable => ScopedMDC => Unit
+		withoutCause : ScopedMDC => Unit,
+		withCause : Throwable => ScopedMDC => Unit
 		)
 		: ScopedMDC => Unit =
-		cause.cata (withError, withoutError)
+		cause.cata (withCause, withoutCause)
 }
 
 
@@ -107,16 +108,16 @@ object LogEntry
 	/**
 	 * This version of the apply method creates a
 	 * [[com.github.osxhacker.demo.chassis.monitoring.logging.LogEntry]] with
-	 * the given '''correlationId''', '''message''', and execution
+	 * the given '''correlationId''', '''message''', and an empty execution
 	 * '''context'''.
 	 */
 	def apply (correlationId : CorrelationId, message : String)
 		(implicit subsystem : Subsystem)
 		: LogEntry =
 		WorkflowLogEntry (
-			correlationId,
 			message,
 			none[Throwable],
+			correlationId,
 			Map.empty
 			)
 
@@ -125,8 +126,8 @@ object LogEntry
 	 * This version of the apply method creates a
 	 * [[com.github.osxhacker.demo.chassis.monitoring.logging.LogEntry]] in the
 	 * presence of the '''cause''' of a problem.  The given '''correlationId''',
-	 * '''message''', and execution '''context''' detail information known when
-	 * the problem was encountered.
+	 * '''message''', and an empty execution '''context''' detail information
+	 * known when the problem was encountered.
 	 */
 	def apply (
 		correlationId : CorrelationId,
@@ -136,9 +137,9 @@ object LogEntry
 		(implicit subsystem : Subsystem)
 		: LogEntry =
 		WorkflowLogEntry (
-			correlationId,
 			message,
-			cause.some,
+			Option (cause),
+			correlationId,
 			Map.empty
 			)
 }
@@ -153,16 +154,16 @@ object LogEntry
  * cannot be made.
  */
 final case class SystemLogEntry (
-	private val message : String,
-	private val cause : Option[Throwable],
-	private val context : Map[String, String]
+	override val message : String,
+	override val cause : Option[Throwable],
+	private val entries : Map[String, String]
 	)
 	(implicit private val subsystem : Subsystem)
-	extends LogEntry (subsystem, message, cause, context)
+	extends LogEntry (message, cause, subsystem, entries)
 {
 	override def addContext (additional : Map[String, String])
 		: SystemLogEntry =
-		copy (context = context ++ additional)
+		copy (entries = context ++ additional)
 }
 
 
@@ -176,17 +177,17 @@ final case class SystemLogEntry (
  * [[com.github.osxhacker.demo.chassis.monitoring.logging.LogEntry]] types.
  */
 final case class WorkflowLogEntry (
+	override val message : String,
+	override val cause : Option[Throwable],
 	private val correlationId : CorrelationId,
-	private val message : String,
-	private val cause : Option[Throwable],
-	private val context : Map[String, String]
+	private val entries : Map[String, String]
 	)
 	(implicit private val subsystem : Subsystem)
 	extends LogEntry (
-		subsystem,
 		message,
 		cause,
-		context.updated (
+		subsystem,
+		entries.updated (
 			"correlationId",
 			Show[CorrelationId].show (correlationId)
 			)
@@ -194,6 +195,6 @@ final case class WorkflowLogEntry (
 {
 	override def addContext (additional : Map[String, String])
 		: WorkflowLogEntry =
-		copy (context = context ++ additional)
+		copy (entries = context ++ additional)
 }
 

--- a/services/chassis/src/main/scala/com/github/osxhacker/demo/chassis/monitoring/logging/Loggable.scala
+++ b/services/chassis/src/main/scala/com/github/osxhacker/demo/chassis/monitoring/logging/Loggable.scala
@@ -1,0 +1,33 @@
+package com.github.osxhacker.demo.chassis.monitoring.logging
+
+
+/**
+ * The '''Loggable''' type defines the `logging` subsystem concept of a type
+ * which can participate in the production of system activity recorded in a
+ * persistent store.  This contract defines the __minimal__ collaborators
+ * required to participate.
+ */
+trait Loggable
+{
+	/// Instance Properties
+	/**
+	 * The cause property represents an [[scala.Option]]al error encountered as
+	 * represented by a [[java.lang.Throwable]] instance.
+	 */
+	def cause : Option[Throwable] = None
+
+	/**
+	 * The context property provides additional information related to associate
+	 * with '''this''' instance.
+	 */
+	def context : Map[String, String] = Map.empty
+
+	/**
+	 * The message property is required to contain a succinct description of the
+	 * information to be logged.  It can be multi-line and should have
+	 * sufficient information within it such that it assists in reasoning about
+	 * system behavior.
+	 */
+	def message : String
+}
+

--- a/services/chassis/src/test/scala/com/github/osxhacker/demo/chassis/domain/IndexedReaderWriterStateErrorTSpec.scala
+++ b/services/chassis/src/test/scala/com/github/osxhacker/demo/chassis/domain/IndexedReaderWriterStateErrorTSpec.scala
@@ -247,8 +247,8 @@ final class IndexedReaderWriterStateErrorTSpec ()
 							_ <- tell[Int] (logEntries (1))
 							env <- ask
 							_ <- tell[Int] (logEntries (2))
-						} yield env.coefficient * initial
-					}
+							} yield env.coefficient * initial
+						}
 
 				assert (steps ne null)
 

--- a/services/chassis/src/test/scala/com/github/osxhacker/demo/chassis/domain/IndexedReaderWriterStateErrorTSpec.scala
+++ b/services/chassis/src/test/scala/com/github/osxhacker/demo/chassis/domain/IndexedReaderWriterStateErrorTSpec.scala
@@ -1,0 +1,481 @@
+package com.github.osxhacker.demo.chassis.domain
+
+import java.lang.{
+	Double => JDouble
+	}
+
+import scala.collection.mutable
+import scala.util.Try
+
+import cats._
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.wordspec.AnyWordSpec
+import com.github.osxhacker.demo.chassis.ProjectSpec
+
+
+/**
+ * The '''IndexedReaderWriterStateErrorTSpec''' type defines the unit-tests
+ * which certify
+ * [[com.github.osxhacker.demo.chassis.domain.IndexedReaderWriterStateErrorT]]
+ * for fitness of purpose and serves as an exemplar of its use.
+ */
+final class IndexedReaderWriterStateErrorTSpec ()
+	extends AnyWordSpec
+		with Diagrams
+		with ProjectSpec
+{
+	/// Class Imports
+	import cats.syntax.applicative._
+	import cats.syntax.either._
+	import mouse.boolean._
+
+
+	/// Class Types
+	type SimpleLog = List[String]
+
+
+	final case class SampleEnv (val coefficient : Int)
+
+
+	"The IndexedReaderWriterStateErrorT type" when {
+		"being defined" must {
+			"support for comprehensions via the script method" in {
+				import IndexedReaderWriterStateErrorT.script
+
+
+				val result = script[ErrorOr, SampleEnv, SimpleLog, Throwable] {
+					combinators =>
+						import combinators._
+
+						for {
+							initial <- get[Int]
+							squared <- inspect[Int, Int] (n => n * n)
+							_ <- inspectF[Int, Int] (_.asRight)
+							_ <- inspectAskF[Int, Int] ((_, _) => 0.asRight)
+							_ <- modify[Int, String] (_.toString)
+							_ <- modifyF[String, JDouble] {
+								sb =>
+									Try (JDouble.valueOf (sb)).toEither
+								}
+
+							ending <- get
+							_ <- setF (ending.asRight)
+							} yield {
+								assert (initial >= 0)
+								assert (squared >= initial)
+								assert (ending.doubleValue () === 1.0)
+
+								ending
+								}
+					}
+
+				assert (result ne null)
+				assert (result.runA (SampleEnv (2), 1).isRight)
+				}
+
+			"support construction by using companion methods" in {
+				import IndexedReaderWriterStateErrorT.{
+					apply => _,
+					applyF => _,
+					_
+					}
+
+
+				val steps =
+					inspectAsk[ErrorOr, SampleEnv, SimpleLog, Throwable, Int, Int] (
+						(env, n) => env.coefficient * n
+						)
+						.flatMap (
+							set[ErrorOr, SampleEnv, SimpleLog, Throwable, Int]
+							)
+
+				assert (steps ne null)
+
+				val result = steps.runS (SampleEnv (3), 3)
+
+				assert (result exists (_._1.isEmpty))
+				assert (result exists (_._2.isRight))
+				assert (result exists (_._2 exists (_ === 9)))
+				}
+
+			"detect errors in the underlying context and recover" in {
+				import IndexedReaderWriterStateErrorT.script
+
+
+				val steps = script[ErrorOr, SampleEnv, SimpleLog, Throwable] {
+					combinators =>
+						import combinators._
+
+						for {
+							_ <- tell[Int] ("before error".pure[List])
+							_ <- liftF[Int, String] (
+								ApplicativeThrow[ErrorOr].raiseError (
+									new RuntimeException ("simulated")
+									)
+								)
+
+							_ <- tell[Int] ("after error".pure[List])
+							skipped <- pure (99)
+							} yield skipped
+					}
+
+				assert (steps ne null)
+
+				val result = steps.run (SampleEnv (1), 1)
+
+				assert (result.isRight)
+				result foreach {
+					case (log, Left (error)) =>
+						assert (log.size === 1)
+						assert (error.getMessage === "simulated")
+
+					case other =>
+						fail (s"unexpected result shape: $other")
+					}
+				}
+			}
+
+		"being evaluated" must {
+			import IndexedReaderWriterStateErrorT.script
+
+
+			"retain log entries when there are no errors" in {
+				val logEntries = Seq (
+					"first log message",
+					"second log message",
+					"third log message"
+					) map (_.pure[List])
+
+				val steps = script[ErrorOr, SampleEnv, SimpleLog, Throwable] {
+					combinators =>
+						import combinators._
+
+						for {
+							_ <- tell[Int] (logEntries (0))
+							initial <- get[Int]
+							_ <- tell[Int] (logEntries (1))
+							env <- ask
+							_ <- tell[Int] (logEntries (2))
+							} yield env.coefficient * initial
+					}
+
+				assert (steps ne null)
+
+				val env = SampleEnv (10)
+				val result = steps.runA (env, 2)
+
+				assert (result.isRight)
+				result foreach {
+					case (log, Right (answer)) =>
+						assert (log.size === logEntries.size)
+						assert (log forall logEntries.flatten.contains)
+						assert (answer === env.coefficient * 2)
+
+					case other =>
+						fail (s"unexpected result shape: $other")
+					}
+				}
+
+			"retain log entries up to the first error and after recovery" in {
+				val expectedLogEntries = Seq (
+					"before error",
+					"first log message",
+					"second log message",
+					"third log message"
+					) map (_.pure[List])
+
+				val steps = script[ErrorOr, SampleEnv, SimpleLog, Throwable] {
+					combinators =>
+						import combinators._
+
+						val initial = for {
+							_ <- tellF[Int] (expectedLogEntries.head.asRight)
+							_ <- liftF (
+								ApplicativeThrow[ErrorOr].raiseError[Int] (
+									new RuntimeException ("simulated")
+									)
+								)
+
+							_ <- tell ("after error".pure[List])
+							} yield 0
+
+						val alternate = for {
+							_ <- tell[Int] (expectedLogEntries (1))
+							initial <- get
+							_ <- tell (expectedLogEntries (2))
+							env <- ask
+							_ <- tell (expectedLogEntries (3))
+						} yield env.coefficient * initial
+
+						initial handleErrorWith (_ => alternate)
+				}
+
+				assert (steps ne null)
+
+				val env = SampleEnv (2)
+				val result = steps.runA (env, 4)
+
+				assert (result.isRight)
+				result foreach {
+					case (log, Right (answer)) =>
+						assert (log.size === expectedLogEntries.size)
+						assert (expectedLogEntries.flatten forall log.contains)
+						assert (log.contains ("after error") === false)
+						assert (answer === env.coefficient * 4)
+
+					case other =>
+						fail (s"unexpected result shape: $other")
+					}
+				}
+
+			"support emitting the log when ran (success)" in {
+				val emitted = mutable.Buffer.empty[String]
+				val logEntries = Seq (
+					"first log message",
+					"second log message",
+					"third log message"
+					) map (_.pure[List])
+
+				val env = SampleEnv (5)
+				val steps = script[ErrorOr, SampleEnv, SimpleLog, Throwable] {
+					combinators =>
+						import combinators._
+
+						for {
+							_ <- tell[Int] (logEntries (0))
+							initial <- get[Int]
+							_ <- tell[Int] (logEntries (1))
+							env <- ask
+							_ <- tell[Int] (logEntries (2))
+						} yield env.coefficient * initial
+					}
+
+				assert (steps ne null)
+
+				val result = steps.runAndReportA (env, 4) {
+					case (_, Left (error)) =>
+						fail (s"unexpected error: $error")
+
+					case (log, Right ((state, computation))) =>
+						assert (log === logEntries.flatten)
+						assert (state === 4)
+						assert (computation === 20)
+
+						emitted.appendAll (log)
+						Applicative[ErrorOr].unit
+					}
+
+				assert (emitted === logEntries.flatten)
+				assert (result.exists (_ === 20))
+				}
+
+			"support emitting the log when ran (error)" in {
+				val emitted = mutable.Buffer.empty[String]
+				val expectedLogEntries = Seq ("before error") map (_.pure[List])
+
+				val steps = script[ErrorOr, SampleEnv, SimpleLog, Throwable] {
+					combinators =>
+						import combinators._
+
+						for {
+							_ <- tellF[Int] (expectedLogEntries.head.asRight)
+							_ <- liftF (
+								ApplicativeThrow[ErrorOr].raiseError[Int] (
+									new RuntimeException ("simulated")
+									)
+								)
+
+							_ <- tell ("after error".pure[List])
+							env <- ask
+							} yield env.coefficient
+					}
+
+				assert (steps ne null)
+
+				val env = SampleEnv (99)
+				val result = steps.runAndReportA (env, 4) {
+					case (log, Left (error)) =>
+						assert (log === expectedLogEntries.flatten)
+						assert (error ne null)
+						emitted.appendAll (log)
+						Applicative[ErrorOr].unit
+
+					case (_, answer) =>
+						fail (s"unexpected success: $answer")
+					}
+
+				assert (emitted === expectedLogEntries.flatten)
+				assert (result.isLeft)
+				assert (result.swap.exists (_.getMessage ne null))
+				}
+
+			"support tailRecM (success)" in {
+				import IndexedReaderWriterStateErrorT.{
+					apply => _,
+					applyF => _,
+					_
+					}
+
+				val countdown =
+					get[ErrorOr, SampleEnv, SimpleLog, Throwable, Int].flatMap {
+						count =>
+							tell (s"countdown... $count".pure[List])
+						}
+					.modify (_ - 1)
+					.inspect (_ > 0)
+					.map (_.asLeft[Int])
+
+				val finished = pure[
+					ErrorOr,
+					SampleEnv,
+					SimpleLog,
+					Throwable,
+					Int,
+					Either[Boolean, Int]
+					] (0.asRight[Boolean])
+
+				val steps = Monad[
+					ReaderWriterStateErrorT[
+						ErrorOr,
+						SampleEnv,
+						SimpleLog,
+						Throwable,
+						Int,
+						*
+						]
+					].tailRecM (true) (_.fold (countdown, finished))
+
+				steps.runA (SampleEnv (1), 10) foreach {
+					case (_, Left (error)) =>
+						fail ("unexpected error detected", error)
+
+					case (log, Right (result)) =>
+						assert (log.size === 10)
+						assert (result === 0)
+					}
+				}
+
+			"support tailRecM (error)" in {
+				import IndexedReaderWriterStateErrorT.{
+					apply => _,
+					applyF => _,
+					_
+					}
+
+				val countdown =
+					get[ErrorOr, SampleEnv, SimpleLog, Throwable, Int].flatMap {
+						count =>
+							tell (s"countdown... $count".pure[List])
+						}
+						.modify (_ - 1)
+						.inspect (_ > 0)
+						.map (_.asLeft[Int])
+
+				val produceError = liftF[
+					ErrorOr,
+					SampleEnv,
+					SimpleLog,
+					Throwable,
+					Int,
+					Either[Boolean, Int]
+					] (
+					ApplicativeThrow[ErrorOr].raiseError (
+						new RuntimeException ()
+						)
+					)
+
+				val steps = Monad[
+					ReaderWriterStateErrorT[
+						ErrorOr,
+						SampleEnv,
+						SimpleLog,
+						Throwable,
+						Int,
+						*
+						]
+					].tailRecM (true) (_.fold (countdown, produceError))
+
+				steps.runA (SampleEnv (1), 10) foreach {
+					case (log, Left (_)) =>
+						assert (log.size === 10)
+
+					case (_, Right (result)) =>
+						fail (s"expected an error not success: $result")
+					}
+				}
+			}
+
+		"participating in Cats type classes" must {
+			type SampleIndexedType[SA, SB, A] = IndexedReaderWriterStateErrorT[
+				ErrorOr,
+				SampleEnv,
+				SimpleLog,
+				Throwable,
+				SA,
+				SB,
+				A
+				]
+
+
+			"provide a Applicative instance" in {
+				val instance = implicitly[
+					Applicative[SampleIndexedType[Any, Any, *]]
+					]
+
+				assert (instance ne null)
+				}
+
+			"provide a ApplicativeError instance" in {
+				val instance = implicitly[
+					ApplicativeError[
+						SampleIndexedType[Unit, Unit, *],
+						Throwable
+						]
+					]
+
+				assert (instance ne null)
+				}
+
+			"provide a Bifunctor instance" in {
+				val instance = implicitly[
+					Bifunctor[SampleIndexedType[String, *, *]]
+					]
+
+				assert (instance ne null)
+				}
+
+			"provide a Contravariant instance" in {
+				val instance = implicitly[
+					Contravariant[SampleIndexedType[*, String, Boolean]]
+					]
+
+				assert (instance ne null)
+				}
+
+			"provide a Functor instance" in {
+				val instance = implicitly[
+					Functor[SampleIndexedType[String, Int, *]]
+					]
+
+				assert (instance ne null)
+				}
+
+			"provide a MonadError instance" in {
+				val instance = implicitly[
+					MonadError[SampleIndexedType[String, String, *], Throwable]
+					]
+
+				assert (instance ne null)
+				}
+
+			"provide a Monad instance" in {
+				val instance = implicitly[
+					Monad[SampleIndexedType[String, String, *]]
+					]
+
+				assert (instance ne null)
+				}
+			}
+		}
+}
+

--- a/services/chassis/src/test/scala/com/github/osxhacker/demo/chassis/domain/ReaderWriterStateErrorTSpec.scala
+++ b/services/chassis/src/test/scala/com/github/osxhacker/demo/chassis/domain/ReaderWriterStateErrorTSpec.scala
@@ -1,0 +1,190 @@
+package com.github.osxhacker.demo.chassis.domain
+
+import java.lang.{
+	Integer => JInteger
+	}
+
+import scala.util.Try
+
+import cats._
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.wordspec.AnyWordSpec
+import com.github.osxhacker.demo.chassis.ProjectSpec
+
+
+/**
+ * The '''ReaderWriterStateErrorTSpec''' type defines the unit-tests which
+ * certify [[com.github.osxhacker.demo.chassis.domain.ReaderWriterStateErrorT]]
+ * for fitness of purpose and serves as an exemplar of its use.
+ */
+final class ReaderWriterStateErrorTSpec ()
+	extends AnyWordSpec
+		with Diagrams
+		with ProjectSpec
+{
+	/// Class Imports
+	import cats.syntax.applicative._
+	import cats.syntax.either._
+	import mouse.boolean._
+
+
+	/// Class Types
+	type SimpleLog = List[String]
+
+
+	final case class SampleEnv (val coefficient : Int)
+
+
+	"The ReaderWriterStateErrorT type" when {
+		"being defined" must {
+			"support for comprehensions via the script method" in {
+				import ReaderWriterStateErrorT.script
+
+
+				val result = script[ErrorOr, SampleEnv, SimpleLog, Throwable, Int] {
+					combinators =>
+						import combinators._
+
+						for {
+							initial <- get
+							squared <- inspect (n => n * n)
+							_ <- inspectF (_.asRight)
+							_ <- inspectAskF ((_, _) => 0.asRight)
+							_ <- modify (identity)
+							_ <- modifyF {
+								i =>
+									Try (
+										JInteger.valueOf (i.toString).toInt
+										).toEither
+								}
+
+							ending <- get
+							_ <- setF (ending.asRight)
+							} yield {
+								assert (initial >= 0)
+								assert (squared >= initial)
+								assert (ending.doubleValue () === 1.0)
+
+								ending
+								}
+					}
+
+				assert (result ne null)
+				assert (result.runA (SampleEnv (2), 1).isRight)
+				}
+
+			"support construction by using companion methods" in {
+				import ReaderWriterStateErrorT._
+
+
+				val steps =
+					inspectAsk[ErrorOr, SampleEnv, SimpleLog, Throwable, Int, Int] (
+						(env, n) => env.coefficient * n
+						)
+						.flatMap (
+							set[ErrorOr, SampleEnv, SimpleLog, Throwable, Int]
+							)
+
+				assert (steps ne null)
+
+				val result = steps.runS (SampleEnv (3), 3)
+
+				assert (result exists (_._1.isEmpty))
+				assert (result exists (_._2.isRight))
+				assert (result exists (_._2 exists (_ === 9)))
+				}
+
+			"detect errors in the underlying context and recover" in {
+				import ReaderWriterStateErrorT.script
+
+
+				val steps = script[ErrorOr, SampleEnv, SimpleLog, Throwable, Int] {
+					combinators =>
+						import combinators._
+
+						for {
+							_ <- tell ("before error".pure[List])
+							_ <- liftF[Int] (
+								ApplicativeThrow[ErrorOr].raiseError (
+									new RuntimeException ("simulated")
+									)
+								)
+
+							_ <- tell ("after error".pure[List])
+							skipped <- pure (99)
+							} yield skipped
+					}
+
+				assert (steps ne null)
+
+				val result = steps.run (SampleEnv (1), 1)
+
+				assert (result.isRight)
+				result foreach {
+					case (log, Left (error)) =>
+						assert (log.size === 1)
+						assert (error.getMessage === "simulated")
+
+					case other =>
+						fail (s"unexpected result shape: $other")
+					}
+				}
+			}
+
+		"participating in Cats type classes" must {
+			type SampleStateType[S, A] = ReaderWriterStateErrorT[
+				ErrorOr,
+				SampleEnv,
+				SimpleLog,
+				Throwable,
+				S,
+				A
+				]
+
+
+			"provide a Applicative instance" in {
+				val instance = implicitly[
+					Applicative[SampleStateType[Any, *]]
+					]
+
+				assert (instance ne null)
+				}
+
+			"provide a ApplicativeError instance" in {
+				val instance = implicitly[
+					ApplicativeError[
+						SampleStateType[Unit, *],
+						Throwable
+						]
+					]
+
+				assert (instance ne null)
+				}
+
+			"provide a Functor instance" in {
+				val instance = implicitly[
+					Functor[SampleStateType[String, *]]
+					]
+
+				assert (instance ne null)
+				}
+
+			"provide a MonadError instance" in {
+				val instance = implicitly[
+					MonadError[SampleStateType[String, *], Throwable]
+					]
+
+				assert (instance ne null)
+				}
+
+			"provide a Monad instance" in {
+				val instance = implicitly[
+					Monad[SampleStateType[String, *]]
+					]
+
+				assert (instance ne null)
+				}
+			}
+		}
+}
+


### PR DESCRIPTION
This enhancement adds the `IndexedReaderWriterStateErrorT` data type to `services-chassis`.  What it provides is retention of `LogT` history in the event computations `IndexedReaderWriterStateErrorT` evaluates result in an error, unlike the behavior of the Cats data type [IndexedReaderWriterStateT](https://www.javadoc.io/doc/org.typelevel/cats-docs_2.13/latest/cats/data/IndexedReaderWriterStateT.html).