### PR TITLE
Fix use of '[[' in 'detect-version-duplicates'.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -68,7 +68,7 @@ addCommandAlias (
 //////////////////////////////
 
 ThisBuild / organization := s"com.github.osxhacker.$systemName"
-ThisBuild / version := "0.7.5"
+ThisBuild / version := "0.7.6"
 
 /// see: https://www.scala-sbt.org/1.x/docs/Publishing.html#Version+scheme
 ThisBuild / versionScheme := Some ("semver-spec")

--- a/scripts/detect-version-duplicates
+++ b/scripts/detect-version-duplicates
@@ -44,7 +44,7 @@ versions() {
 # MAIN
 ########################################################################
 
-if [[ "${GITHUB_ACTIONS:-false}" = "false" ]]
+if [ "${GITHUB_ACTIONS:-false}" = "false" ]
 then
 	cd $(dirname $0) && cd $(git rev-parse --show-toplevel) || {
 		echo "unable to cd to the project top-level directory" > /dev/stderr


### PR DESCRIPTION
The Linux version of '/bin/sh' behaves differently than what was used by development machines - the former does not support the '[[' test operator whereas the latter did.